### PR TITLE
Added registration to Bootstrap close event to remove alert from the internal collection.

### DIFF
--- a/lib/bootstrap-alerts_templates.js
+++ b/lib/bootstrap-alerts_templates.js
@@ -19,6 +19,12 @@ Template.bootstrapAlert.rendered = function () {
                 alert.options.autoHide);
         }
     });
+
+    // Register on Bootstrap Alert close event in order to remove the alert from the internal collection
+    $node.on("closed.bs.alert", function () {
+        Alerts.removeById(alert._id);
+    });
+
 };
 
 Template.bootstrapAlerts.helpers({


### PR DESCRIPTION
I've made this little modification to remove alerts from the internal collection when closed with the Bootstrap dismiss button. This is useful for example when one wants to have a reliable alerts count to implement a total indicator (I put an icon on the toolbar showing the number of pending alert messages).